### PR TITLE
Rename package to meet style standards conventions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,11 +3,11 @@ plugins {
 }
 
 android {
-    namespace = "com.example.group_5_project"
+    namespace = "com.example.periodtracker"
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.example.group_5_project"
+        applicationId = "com.example.periodtracker"
         minSdk = 24
         targetSdk = 33
         versionCode = 1

--- a/app/src/androidTest/java/com/example/periodtracker/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/periodtracker/ExampleInstrumentedTest.java
@@ -1,4 +1,4 @@
-package com.example.group_5_project;
+package com.example.periodtracker;
 
 import android.content.Context;
 

--- a/app/src/main/java/com/example/periodtracker/MainActivity.java
+++ b/app/src/main/java/com/example/periodtracker/MainActivity.java
@@ -1,4 +1,4 @@
-package com.example.group_5_project;
+package com.example.periodtracker;
 
 import androidx.appcompat.app.AppCompatActivity;
 

--- a/app/src/test/java/com/example/periodtracker/ExampleUnitTest.java
+++ b/app/src/test/java/com/example/periodtracker/ExampleUnitTest.java
@@ -1,4 +1,4 @@
-package com.example.group_5_project;
+package com.example.periodtracker;
 
 import org.junit.Test;
 


### PR DESCRIPTION
This patch renames the package to meet the style standards consisting of lowercase characters without underscores. This will remove the warnings produced by CheckStyle when following our custom style format.