### PR TITLE
Set rotation lock for all activities within the application

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,31 +16,30 @@
         tools:targetApi="31">
         <activity
             android:name=".SymptomsActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".Health"
-            android:exported="false" />
+            android:exported="false"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".Home"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".Today"
-            android:exported="false"></activity>
-
-        <receiver android:name=".NotificationAlarmManager" />
-
+            android:exported="false"
+            android:screenOrientation="portrait"></activity>
         <activity
             android:name=".SymptomsInputActivity"
             android:screenOrientation="portrait"></activity>
+        <receiver android:name=".NotificationAlarmManager" />
     </application>
-
-
 
 </manifest>


### PR DESCRIPTION
This commit locks all activities to be in portrait mode due to user feedback describing issues with rotating the phone and the UI being unusable.